### PR TITLE
Support webpack to build single file (for browsers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log
 node_modules/
 coverage/
 dist/
+release/

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "babel": "5",
+    "babel-loader": "^5.3.2",
     "istanbul-harmony": "0",
     "mocha": "2"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+    entry: './lib/index',
+
+    output: {
+        filename: 'typed-object.js',
+        path: 'release'
+    },
+
+    module: {
+        loaders: [
+            {
+                test: /\.js/,
+                exclude: /node_modules/,
+                loader: 'babel-loader'
+            }
+        ]
+    }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ module.exports = {
     entry: './lib/index',
 
     output: {
-        filename: 'typed-object.js',
+        filename: 'typed-objects.js',
         path: 'release'
     },
 


### PR DESCRIPTION
@coderhaoxin what about idea for build single file, ex. for browsers.

My colegue use your implementation of ES7 Typed Objects in hit presentation about ES7.
More https://github.com/ksyrytczyk/presentation-warsawjs-es7

I use `webpack` to build single file in `release` directory.
Of course add this dir to `.gitignore`.